### PR TITLE
Add admin commands for subscriber management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Guardiandeldivan
-odex/haz-commit-de-los-cambios-en-la-rama-principal
 Un bot de Telegram para administrar un canal de pago mediante suscripciones.
 
 ## Requisitos
@@ -15,7 +14,7 @@ pip install -r requirements.txt
 
 ## Uso rápido
 
-Crea las variables de entorno `BOT_TOKEN` (token de tu bot) y `CHANNEL_ID` (ID del canal a administrar) y ejecuta:
+Crea las variables de entorno `BOT_TOKEN` (token de tu bot), `CHANNEL_ID` (ID del canal a administrar) y `ADMIN_IDS` (lista de IDs de administradores separada por comas). Luego ejecuta:
 
 ```bash
 python -m bot.main
@@ -27,7 +26,14 @@ python -m bot.main
 - `bot/database.py` - Funciones de acceso a base de datos SQLite
 - `bot/token_manager.py` - Generación y validación de tokens de suscripción
 
+### Comandos de administración
+
+- `/admin` muestra la ayuda de administradores.
+- `/gen_token <duracion>` genera un token.
+- `/add_sub <user_id> <duracion>` da de alta a un usuario manualmente.
+- `/remove_sub <user_id>` da de baja a un usuario.
+- `/list_subs` lista los usuarios activos con su fecha de entrada.
+
 ## Notas de desarrollo
 
 El bot gestiona usuarios, fechas de ingreso y expiración de suscripciones. Envía recordatorios por privado y expulsa del canal cuando la suscripción expira. Los administradores podrán consultar estadísticas básicas.
-main

--- a/bot/database.py
+++ b/bot/database.py
@@ -69,3 +69,26 @@ def subscription_expired(sub: dict) -> bool:
     end_date = sub["start_date"] + timedelta(days=sub["duration"])
     return datetime.utcnow() > end_date
 
+
+def list_active_subscriptions() -> list[dict]:
+    """Return a list of active subscriptions with parsed dates."""
+    conn = sqlite3.connect(DB_NAME)
+    c = conn.cursor()
+    c.execute(
+        "SELECT user_id, token, start_date, duration, renewals FROM subscriptions"
+    )
+    rows = c.fetchall()
+    conn.close()
+    result = []
+    for row in rows:
+        sub = {
+            "user_id": row[0],
+            "token": row[1],
+            "start_date": datetime.fromisoformat(row[2]),
+            "duration": row[3],
+            "renewals": row[4],
+        }
+        if not subscription_expired(sub):
+            result.append(sub)
+    return result
+

--- a/bot/main.py
+++ b/bot/main.py
@@ -10,6 +10,7 @@ from .database import (
     get_subscription,
     remove_subscription,
     subscription_expired,
+    list_active_subscriptions,
     DB_NAME,
 )
 from .token_manager import generate_token
@@ -20,12 +21,31 @@ logger = logging.getLogger(__name__)
 
 BOT_TOKEN = os.getenv("BOT_TOKEN")
 CHANNEL_ID = os.getenv("CHANNEL_ID")  # ID del canal a administrar
+ADMIN_IDS = [int(x) for x in os.getenv("ADMIN_IDS", "").split(",") if x]
+
+
+def is_admin(user_id: int) -> bool:
+    return user_id in ADMIN_IDS
+
+
+def admin_only(func):
+    def wrapper(update: Update, context: CallbackContext):
+        user_id = update.effective_user.id
+        if not is_admin(user_id):
+            update.message.reply_text("Acceso denegado")
+            return
+        return func(update, context)
+
+    return wrapper
 
 
 def start(update: Update, context: CallbackContext):
-    update.message.reply_text("Bienvenido. Usa /gen_token <duracion> para obtener un token.")
+    update.message.reply_text(
+        "Bienvenido. Contacta con un administrador para obtener un token y luego usa /join <token>."
+    )
 
 
+@admin_only
 def gen_token(update: Update, context: CallbackContext):
     if len(context.args) != 1:
         update.message.reply_text("Uso: /gen_token <1d|1w|2w|1m|forever>")
@@ -47,6 +67,59 @@ def join(update: Update, context: CallbackContext):
         return
     context.bot.invite_chat_member(CHANNEL_ID, update.effective_user.id)
     update.message.reply_text("Acceso concedido al canal")
+
+
+@admin_only
+def add_sub(update: Update, context: CallbackContext):
+    if len(context.args) != 2:
+        update.message.reply_text("Uso: /add_sub <user_id> <duracion>")
+        return
+    try:
+        user_id = int(context.args[0])
+    except ValueError:
+        update.message.reply_text("user_id debe ser numerico")
+        return
+    key = context.args[1]
+    token, days = generate_token(key)
+    add_subscription(user_id, token, days)
+    update.message.reply_text(f"Suscripcion creada para {user_id}. Token: {token}")
+
+
+@admin_only
+def remove_sub(update: Update, context: CallbackContext):
+    if len(context.args) != 1:
+        update.message.reply_text("Uso: /remove_sub <user_id>")
+        return
+    try:
+        user_id = int(context.args[0])
+    except ValueError:
+        update.message.reply_text("user_id debe ser numerico")
+        return
+    remove_subscription(user_id)
+    update.message.reply_text("Suscripcion eliminada")
+
+
+@admin_only
+def list_subs(update: Update, context: CallbackContext):
+    subs = list_active_subscriptions()
+    if not subs:
+        update.message.reply_text("No hay suscriptores activos")
+        return
+    lines = [
+        f"{s['user_id']} - {s['start_date'].strftime('%Y-%m-%d')}" for s in subs
+    ]
+    update.message.reply_text("\n".join(lines))
+
+
+@admin_only
+def admin_help(update: Update, context: CallbackContext):
+    update.message.reply_text(
+        "Comandos admin:\n"
+        "/gen_token <duracion> - Generar token para un usuario\n"
+        "/add_sub <user_id> <duracion> - Alta manual\n"
+        "/remove_sub <user_id> - Baja manual\n"
+        "/list_subs - Listar suscriptores activos"
+    )
 
 
 def check_expirations(context: CallbackContext):
@@ -79,6 +152,10 @@ def main():
     dp.add_handler(CommandHandler("gen_token", gen_token))
     dp.add_handler(CommandHandler("join", join))
     dp.add_handler(CommandHandler("stats", stats))
+    dp.add_handler(CommandHandler("add_sub", add_sub))
+    dp.add_handler(CommandHandler("remove_sub", remove_sub))
+    dp.add_handler(CommandHandler("list_subs", list_subs))
+    dp.add_handler(CommandHandler("admin", admin_help))
 
     job_queue = updater.job_queue
     job_queue.run_repeating(check_expirations, interval=3600, first=0)


### PR DESCRIPTION
## Summary
- generate admin-only tokens
- add commands to manually manage subscriptions
- list active subscriber start dates
- document new admin features and environment variable

## Testing
- `python -m py_compile bot/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684b91f9c66c83298019b90727f8448e