### PR TITLE
Add Railway deployment configuration

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: python -m bot.main

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ Instala las dependencias con:
 pip install -r requirements.txt
 ```
 
+## Despliegue en Railway
+
+1. Crea un proyecto en [Railway](https://railway.app/).
+2. Configura en el panel las variables de entorno `BOT_TOKEN`, `CHANNEL_ID` y `ADMIN_IDS`.
+3. El repositorio incluye un `Procfile` con el comando necesario para iniciar el bot:
+
+   ```
+   worker: python -m bot.main
+   ```
+
+Al desplegar, Railway utilizará este archivo automáticamente para ejecutar el bot.
+
 ## Uso rápido
 
 Crea las variables de entorno `BOT_TOKEN` (token de tu bot), `CHANNEL_ID` (ID del canal a administrar) y `ADMIN_IDS` (lista de IDs de administradores separada por comas). Luego ejecuta:


### PR DESCRIPTION
## Summary
- add Procfile to specify Railway command
- document Railway deployment instructions in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bb663e1548329839cd179500465bc