### PR TITLE
Add help command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ python -m bot.main
 - `/remove_sub <user_id>` da de baja a un usuario.
 - `/list_subs` lista los usuarios activos con su fecha de entrada.
 
+### Comandos de usuario
+
+- `/start` muestra la bienvenida.
+- `/help` lista los comandos disponibles.
+- `/join <token>` accede al canal con un token.
+- `/stats` muestra el numero total de suscriptores.
+
 ## Notas de desarrollo
 
 El bot gestiona usuarios, fechas de ingreso y expiración de suscripciones. Envía recordatorios por privado y expulsa del canal cuando la suscripción expira. Los administradores podrán consultar estadísticas básicas.

--- a/bot/main.py
+++ b/bot/main.py
@@ -133,6 +133,17 @@ async def admin_help(update: Update, context: ContextTypes.DEFAULT_TYPE):
     )
 
 
+async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Mostrar los comandos disponibles para cualquier usuario."""
+    await update.message.reply_text(
+        "Comandos disponibles:\n"
+        "/start - Mensaje de bienvenida\n"
+        "/join <token> - Unirte al canal con un token valido\n"
+        "/stats - Estadisticas basicas\n"
+        "/help - Mostrar esta ayuda"
+    )
+
+
 async def check_expirations(context: ContextTypes.DEFAULT_TYPE):
     for sub in list_active_subscriptions():
         if subscription_expired(sub):
@@ -168,6 +179,7 @@ def main() -> None:
     application.add_handler(CommandHandler("remove_sub", remove_sub))
     application.add_handler(CommandHandler("list_subs", list_subs))
     application.add_handler(CommandHandler("admin", admin_help))
+    application.add_handler(CommandHandler("help", help_command))
 
     application.job_queue.run_repeating(check_expirations, interval=3600, first=0)
 


### PR DESCRIPTION
## Summary
- add `/help` command for general users
- register help handler in bot
- document new command in README

## Testing
- `python -m py_compile bot/main.py bot/database.py bot/token_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bbf90e8e88329b357c0289832ed39