### PR TITLE
Implement configuration and admin menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ python -m bot.main
 - `/add_sub <user_id> <duracion>` da de alta a un usuario manualmente.
 - `/remove_sub <user_id>` da de baja a un usuario.
 - `/list_subs` lista los usuarios activos con su fecha de entrada.
+- `/set_rate <dias> <monto>` define la tarifa y periodo de cobro.
+- `/broadcast <mensaje>` envía un mensaje a todos los suscriptores.
+- `/gen_link <user_id> <duracion>` genera un enlace con token para un usuario.
 
 ### Comandos de usuario
 


### PR DESCRIPTION
## Summary
- support persistent settings in database
- implement set_rate, broadcast and link generation commands
- expand inline menus for configuration and administration
- document new admin commands

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c8f6334dc83298619c03b83dae9ec