### PR TITLE
Add token request user menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ python -m bot.main
 - `/menu` muestra un menú con botones para los comandos.
 - `/join <token>` accede al canal con un token.
 - `/stats` muestra el numero total de suscriptores.
+- Desde el menú de usuario puedes pulsar **Solicitar token** para que los administradores generen uno.
 
 ## Notas de desarrollo
 


### PR DESCRIPTION
## Summary
- show admin options only to admins in menu
- add token request option for regular users and notify admins
- document new menu behaviour in README

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684c90f0fd0083298b156bab633d2b73