### PR TITLE
Improve token system and stats formatting

### DIFF
--- a/bot/token_manager.py
+++ b/bot/token_manager.py
@@ -17,3 +17,12 @@ def generate_token(duration_key: str) -> tuple[str, int]:
     token = secrets.token_urlsafe(8)
     return token, duration
 
+
+def create_token(duration_key: str):
+    """Create and store a token, returning it and its duration."""
+    from .database import save_token
+
+    token, duration = generate_token(duration_key)
+    save_token(token, duration)
+    return token, duration
+


### PR DESCRIPTION
## Summary
- add `tokens` table and helper functions
- update token generation and join flow to use single-use tokens
- provide admin menu buttons for generating tokens
- enhance `/stats` output with formatted details

## Testing
- `python -m py_compile bot/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684c953d4a048329894e8c092ac4770d