### PR TITLE
Fix admin menu actions and add back buttons

### DIFF
--- a/bot/messages.py
+++ b/bot/messages.py
@@ -2,7 +2,7 @@ MESSAGES = {
     "access_denied": "⛔ Acceso denegado",
     "start": "👋 Bienvenido. Contacta con un administrador para obtener un token y luego selecciona una opción:",
     "gen_token_usage": "📝 Uso: /gen_token <1d|1w|2w|1m|forever>",
-    "gen_token_result": "🔑 Tu token es: {token}. Válido por {days} días.",
+    "gen_token_result": "🔗 Enlace de acceso: {link}\nVálido por {days} días.",
     "join_token_missing": "🔑 Debes proporcionar el token",
     "join_token_invalid": "❌ Token inválido o expirado",
     "join_success": "✅ Acceso concedido al canal: {link}",
@@ -16,8 +16,10 @@ MESSAGES = {
     "set_rate_usage": "📝 Uso: /set_rate <dias> <monto>",
     "set_rate_invalid": "⚠️ Valores inválidos",
     "set_rate_saved": "✅ Tarifa guardada: cada {days} días por {amount}",
+    "set_rate_prompt": "📝 Envía la tarifa en formato <dias> <monto>:",
     "broadcast_usage": "📝 Uso: /broadcast <mensaje>",
     "broadcast_sent": "✅ Mensaje enviado a {sent} usuarios",
+    "broadcast_prompt": "📝 Envía el mensaje a todos los suscriptores:",
     "gen_link_usage": "📝 Uso: /gen_link <user_id> <duracion>",
     "gen_link_user_id_numeric": "⚠️ user_id debe ser numérico",
     "gen_link_result": "🔗 Enlace de acceso: {link}",
@@ -27,8 +29,7 @@ MESSAGES = {
         "/remove_sub <user_id> - Baja manual\n"
         "/list_subs - Listar suscriptores activos\n"
         "/set_rate <dias> <monto> - Configurar tarifa\n"
-        "/broadcast <mensaje> - Enviar mensaje a todos\n"
-        "/gen_link <user_id> <duracion> - Generar link con token"
+        "/broadcast <mensaje> - Enviar mensaje a todos"
     ),
     "help": (
         "ℹ️ <b>Comandos disponibles</b>:\n"
@@ -45,7 +46,7 @@ MESSAGES = {
     "token_duration_menu": "🕒 Elige duración para el token:",
     "subscriber_not_found": "❌ Suscriptor no encontrado",
     "user_removed": "✅ Usuario expulsado",
-    "token_generated": "🔑 Token generado:\n{token}\nVálido por {days} días",
+    "token_generated": "🔗 Enlace generado:\n{link}\nVálido por {days} días",
     "add_sub_menu_usage": "📝 Uso: /add_sub <user_id> <duracion>",
     "remove_sub_menu_usage": "📝 Uso: /remove_sub <user_id>",
     "join_menu_usage": "📝 Uso: /join <token>",


### PR DESCRIPTION
## Summary
- return link instead of token for `/gen_token`
- add prompts for broadcast and rate config
- include back buttons in stats and token generation
- remove 'Generar link' option from admin menu
- handle broadcast and rate via text replies

## Testing
- `python -m py_compile bot/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c9a536a048329949f8aaa129908f7