### PR TITLE
Add token listing command with filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ python -m bot.main
 - `/set_rate <dias> <monto>` define la tarifa y periodo de cobro.
 - `/broadcast <mensaje>` envía un mensaje a todos los suscriptores.
 - `/gen_link <user_id> <duracion>` genera un enlace con token para un usuario.
+- `/list_tokens [user_id] [desde] [hasta]` muestra los tokens generados con filtros opcionales.
 
 ### Comandos de usuario
 

--- a/bot/messages.py
+++ b/bot/messages.py
@@ -20,6 +20,8 @@ MESSAGES = {
     "broadcast_usage": "📝 Uso: /broadcast <mensaje>",
     "broadcast_sent": "✅ Mensaje enviado a {sent} usuarios",
     "broadcast_prompt": "📝 Envía el mensaje a todos los suscriptores:",
+    "list_tokens_usage": "📝 Uso: /list_tokens [user_id] [desde] [hasta]",
+    "list_tokens_none": "ℹ️ No se encontraron tokens",
     "gen_link_usage": "📝 Uso: /gen_link <user_id> <duracion>",
     "gen_link_user_id_numeric": "⚠️ user_id debe ser numérico",
     "gen_link_result": "🔗 Enlace de acceso: {link}",


### PR DESCRIPTION
## Summary
- add `/list_tokens` admin command to query generated tokens by user or date
- support token listing via inline menu under *Administración*
- update database layer with `list_tokens` function
- document new command in README

## Testing
- `python -m py_compile bot/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cf6ef7b488329b86ae2cd0e7588be