### PR TITLE
Improve /start command logic

### DIFF
--- a/bot/database.py
+++ b/bot/database.py
@@ -299,6 +299,29 @@ def get_all_user_subscriptions() -> list[dict]:
     return result
 
 
+def get_user_subscription(user_id: int) -> Optional[dict]:
+    """Retrieve a user subscription if it exists."""
+    conn = sqlite3.connect(DB_NAME)
+    c = conn.cursor()
+    c.execute(
+        "SELECT user_id, username, full_name, join_date, expiration_date, reminded, expired_notified FROM user_subscriptions WHERE user_id=?",
+        (user_id,),
+    )
+    row = c.fetchone()
+    conn.close()
+    if row:
+        return {
+            "user_id": row[0],
+            "username": row[1],
+            "full_name": row[2],
+            "join_date": datetime.fromisoformat(row[3]),
+            "expiration_date": datetime.fromisoformat(row[4]),
+            "reminded": row[5],
+            "expired_notified": row[6],
+        }
+    return None
+
+
 def mark_user_reminded(user_id: int):
     conn = sqlite3.connect(DB_NAME)
     c = conn.cursor()

--- a/bot/handlers/user/start.py
+++ b/bot/handlers/user/start.py
@@ -1,24 +1,34 @@
 from datetime import datetime, timedelta
 import os
 
-from telegram import Update
-from telegram.ext import ContextTypes
+from aiogram import Router, types
+from aiogram.filters import Command, CommandObject
 
-from ...database import use_token, add_user_subscription
+from ...database import (
+    use_token,
+    add_user_subscription,
+    get_user_subscription,
+)
+from ..admin.config_messages import is_admin
 
 CHANNEL_ID = os.getenv("CHANNEL_ID")
 
+router = Router()
 
-async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Handle /start <token> command."""
-    args = context.args
-    if args:
-        token = args[0]
+
+@router.message(Command("start"))
+async def start(message: types.Message, command: CommandObject) -> None:
+    """Handle /start command with optional token."""
+
+    token = command.args
+    user = message.from_user
+
+    if token:
         duration = use_token(token)
         if not duration:
-            await update.effective_message.reply_text("❌ Token inválido")
+            await message.answer("Invalid or expired token.")
             return
-        user = update.effective_user
+
         expiration = datetime.utcnow() + timedelta(days=duration)
         add_user_subscription(
             user.id,
@@ -26,14 +36,44 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
             user.full_name or "",
             expiration,
         )
-        invite = await context.bot.create_chat_invite_link(
+
+        invite = await message.bot.create_chat_invite_link(
             CHANNEL_ID, member_limit=1
         )
-        await update.effective_message.reply_text(
-            f"✅ Registro exitoso. Únete aquí: {invite.invite_link}"
+        await message.answer(
+            f"Welcome! Join here: {invite.invite_link}"
+        )
+        return
+
+    # No token provided
+    if is_admin(user.id):
+        keyboard = [
+            [types.InlineKeyboardButton(text="Configuration", callback_data="configuracion")],
+            [types.InlineKeyboardButton(text="Administration", callback_data="administracion")],
+        ]
+        await message.answer(
+            "Admin menu:",
+            reply_markup=types.InlineKeyboardMarkup(inline_keyboard=keyboard),
+        )
+        return
+
+    sub = get_user_subscription(user.id)
+    if sub:
+        keyboard = [
+            [types.InlineKeyboardButton(text="Profile", callback_data="profile")],
+            [
+                types.InlineKeyboardButton(
+                    text="Check Subscription", callback_data="check_subscription"
+                )
+            ],
+            [types.InlineKeyboardButton(text="Help", callback_data="help")],
+        ]
+        await message.answer(
+            "Subscriber menu:",
+            reply_markup=types.InlineKeyboardMarkup(inline_keyboard=keyboard),
         )
     else:
-        await update.effective_message.reply_text(
-            "Envía /start <token> para activar tu suscripción"
+        await message.answer(
+            "You are not subscribed. Please contact support."
         )
 


### PR DESCRIPTION
## Summary
- update `/start` handler to use aiogram router
- show different menus depending on token, admin status and subscription
- add helper to look up user subscriptions

## Testing
- `python -m py_compile bot/handlers/user/start.py bot/database.py`

------
https://chatgpt.com/codex/tasks/task_e_684d7e61ee4c832992b8cb2681c0f14f