### PR TITLE
Add database models and init

### DIFF
--- a/database/__init__.py
+++ b/database/__init__.py
@@ -1,0 +1,24 @@
+import aiosqlite
+from pathlib import Path
+
+from .models import SCHEMA
+
+_db: aiosqlite.Connection | None = None
+
+
+async def init_db(path: str = "db.sqlite3") -> aiosqlite.Connection:
+    """Initialize the SQLite database and return the connection."""
+    global _db
+    if _db is None:
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        _db = await aiosqlite.connect(path)
+        await _db.executescript(SCHEMA)
+        await _db.commit()
+    return _db
+
+
+def get_db() -> aiosqlite.Connection:
+    """Return the initialized database connection."""
+    if _db is None:
+        raise RuntimeError("Database not initialized")
+    return _db

--- a/database/models.py
+++ b/database/models.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+# SQLite schema definitions and data models
+
+@dataclass
+class User:
+    id: int
+    username: str
+    full_name: str
+    is_admin: bool
+
+
+@dataclass
+class Subscription:
+    user_id: int
+    start_date: datetime
+    end_date: datetime
+
+
+@dataclass
+class Token:
+    token: str
+    duration_days: int
+    used: bool
+
+
+@dataclass
+class Config:
+    key: str
+    value: str
+
+# SQL commands to create tables
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS user (
+    id INTEGER PRIMARY KEY,
+    username TEXT NOT NULL UNIQUE,
+    full_name TEXT NOT NULL,
+    is_admin INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS subscription (
+    user_id INTEGER NOT NULL REFERENCES user(id) ON DELETE CASCADE,
+    start_date TEXT NOT NULL,
+    end_date TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS token (
+    token TEXT PRIMARY KEY,
+    duration_days INTEGER NOT NULL,
+    used INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS config (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+"""


### PR DESCRIPTION
## Summary
- define dataclass models for User, Subscription, Token and Config
- add SQL schema constants
- add database initialization logic

## Testing
- `python -m py_compile database/__init__.py database/models.py`

------
https://chatgpt.com/codex/tasks/task_e_684d88a0ed8483299abda2fc02af0507