### PR TITLE
Add database models and init

### DIFF
--- a/database/__init__.py
+++ b/database/__init__.py
@@ -12,6 +12,7 @@ async def init_db(path: str = "db.sqlite3") -> aiosqlite.Connection:
     if _db is None:
         Path(path).parent.mkdir(parents=True, exist_ok=True)
         _db = await aiosqlite.connect(path)
+        _db.row_factory = aiosqlite.Row
         await _db.executescript(SCHEMA)
         await _db.commit()
     return _db

--- a/database/models.py
+++ b/database/models.py
@@ -1,6 +1,14 @@
 from dataclasses import dataclass
 from datetime import datetime
 
+__all__ = [
+    "User",
+    "Subscription",
+    "Token",
+    "Config",
+    "SCHEMA",
+]
+
 # SQLite schema definitions and data models
 
 @dataclass


### PR DESCRIPTION
## Summary
- add module exports for database models
- configure `aiosqlite` row factory during initialization

## Testing
- `python -m py_compile database/__init__.py database/models.py`


------
https://chatgpt.com/codex/tasks/task_e_684d89456ae0832993e4cc064fa95b59