### PR TITLE
Add subscription management service

### DIFF
--- a/services/subscription_service.py
+++ b/services/subscription_service.py
@@ -1,0 +1,87 @@
+import datetime
+from typing import List, Optional
+
+from database import get_db
+from database.models import Subscription
+
+__all__ = [
+    "add_subscription",
+    "get_subscription",
+    "remove_subscription",
+    "list_active_subscriptions",
+]
+
+
+async def add_subscription(user_id: int, duration_days: int) -> None:
+    """Add or extend a user's subscription."""
+    db = get_db()
+    now = datetime.datetime.utcnow()
+    async with db.execute(
+        "SELECT start_date, end_date FROM subscription WHERE user_id=?",
+        (user_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+
+    if row:
+        start = datetime.datetime.fromisoformat(row["start_date"])
+        end = datetime.datetime.fromisoformat(row["end_date"])
+        if end < now:
+            start = now
+            end = now + datetime.timedelta(days=duration_days)
+        else:
+            end = end + datetime.timedelta(days=duration_days)
+        await db.execute(
+            "UPDATE subscription SET start_date=?, end_date=? WHERE user_id=?",
+            (start.isoformat(), end.isoformat(), user_id),
+        )
+    else:
+        start = now
+        end = now + datetime.timedelta(days=duration_days)
+        await db.execute(
+            "INSERT INTO subscription (user_id, start_date, end_date) VALUES (?, ?, ?)",
+            (user_id, start.isoformat(), end.isoformat()),
+        )
+    await db.commit()
+
+
+async def get_subscription(user_id: int) -> Optional[Subscription]:
+    """Return the subscription for the given user if it exists."""
+    db = get_db()
+    async with db.execute(
+        "SELECT user_id, start_date, end_date FROM subscription WHERE user_id=?",
+        (user_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    if row is None:
+        return None
+    return Subscription(
+        user_id=row["user_id"],
+        start_date=datetime.datetime.fromisoformat(row["start_date"]),
+        end_date=datetime.datetime.fromisoformat(row["end_date"]),
+    )
+
+
+async def remove_subscription(user_id: int) -> None:
+    """Remove a user's subscription."""
+    db = get_db()
+    await db.execute("DELETE FROM subscription WHERE user_id=?", (user_id,))
+    await db.commit()
+
+
+async def list_active_subscriptions() -> List[Subscription]:
+    """Return a list of currently active subscriptions."""
+    db = get_db()
+    now = datetime.datetime.utcnow().isoformat()
+    async with db.execute(
+        "SELECT user_id, start_date, end_date FROM subscription WHERE end_date>?",
+        (now,),
+    ) as cursor:
+        rows = await cursor.fetchall()
+    return [
+        Subscription(
+            user_id=row["user_id"],
+            start_date=datetime.datetime.fromisoformat(row["start_date"]),
+            end_date=datetime.datetime.fromisoformat(row["end_date"]),
+        )
+        for row in rows
+    ]


### PR DESCRIPTION
## Summary
- implement subscription service with async helpers to add, get, remove and list subscriptions

## Testing
- `python -m py_compile services/subscription_service.py`
- `python - <<'PY'
import asyncio
from services.subscription_service import add_subscription, get_subscription, remove_subscription, list_active_subscriptions
from database import init_db
async def test():
    db = await init_db(':memory:')
    await db.execute('INSERT INTO user (id, username, full_name, is_admin) VALUES (1, "u", "U", 0)')
    await db.commit()
    await add_subscription(1, 30)
    sub = await get_subscription(1)
    assert sub.user_id == 1
    assert sub.end_date > sub.start_date
    await remove_subscription(1)
    assert await get_subscription(1) is None
    await add_subscription(1, 15)
    acts = await list_active_subscriptions()
    assert len(acts) == 1
    print('ok')

asyncio.run(test())
PY

------
https://chatgpt.com/codex/tasks/task_e_684d8b0b45748329911b5013ce394f1f