### PR TITLE
Implement /start token logic

### DIFF
--- a/handlers/user/__init__.py
+++ b/handlers/user/__init__.py
@@ -1,0 +1,3 @@
+from .start import router as start_router
+
+__all__ = ["start_router"]

--- a/handlers/user/start.py
+++ b/handlers/user/start.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import datetime
+
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import Message
+
+from database import get_db
+from services.subscription_service import add_subscription, get_subscription
+from services.token_service import validate_token, mark_token_as_used
+
+router = Router()
+
+FAKE_INVITE_LINK = "https://t.me/+fake_invite"  # placeholder
+
+
+@router.message(Command("start"))
+async def cmd_start(message: Message, command: Command.CommandObject) -> None:
+    db = get_db()
+
+    tg_user = message.from_user
+    if tg_user is None:
+        return
+
+    # Ensure user exists in DB
+    await db.execute(
+        "INSERT OR IGNORE INTO user (id, username, full_name) VALUES (?, ?, ?)",
+        (tg_user.id, tg_user.username or "", tg_user.full_name or ""),
+    )
+    await db.commit()
+
+    token = command.args.strip() if command.args else None
+    if token:
+        duration = await validate_token(token)
+        if duration is None:
+            await message.answer("Token inválido")
+            return
+        await mark_token_as_used(token)
+        await add_subscription(tg_user.id, duration)
+        await message.answer(
+            f"Suscripción activada por {duration} días.\nInvitación: {FAKE_INVITE_LINK}"
+        )
+        return
+
+    # Determine role and show menu
+    async with db.execute("SELECT is_admin FROM user WHERE id=?", (tg_user.id,)) as cur:
+        row = await cur.fetchone()
+    is_admin = row and row["is_admin"] == 1
+
+    sub = await get_subscription(tg_user.id)
+    active = sub and sub.end_date > datetime.datetime.utcnow()
+
+    if is_admin:
+        await message.answer("Menú de administración")
+    elif active:
+        await message.answer("Menú de suscriptor")
+    else:
+        await message.answer(
+            "No estás registrado. Solicita un token y envía /start <token> para suscribirte."
+        )

--- a/main.py
+++ b/main.py
@@ -1,9 +1,13 @@
 import asyncio
 
 from bot import bot, dp
+from database import init_db
+from handlers.user import start_router
 
 
 async def main() -> None:
+    await init_db()
+    dp.include_router(start_router)
     await dp.start_polling(bot)
 
 


### PR DESCRIPTION
## Summary
- handle `/start <token>` to activate subscription
- show menus based on admin or subscriber status
- initialize DB and include new router

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d93645b408329af13c980b6faa417