### PR TITLE
Add subscription expiration monitor

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,12 +2,14 @@ import asyncio
 
 from bot import bot, dp
 from database import init_db
+from tools.subscription_monitor import monitor_subscriptions
 from handlers.user import start_router
 from handlers.admin import token_router, users_router
 
 
 async def main() -> None:
     await init_db()
+    asyncio.create_task(monitor_subscriptions())
     dp.include_router(start_router)
     dp.include_router(token_router)
     dp.include_router(users_router)

--- a/tools/subscription_monitor.py
+++ b/tools/subscription_monitor.py
@@ -1,0 +1,43 @@
+import asyncio
+import datetime
+
+from aiogram.exceptions import TelegramAPIError
+
+from bot import bot
+from database import get_db
+from services.subscription_service import remove_subscription
+
+
+async def _check_subscriptions() -> None:
+    """Check all subscriptions and notify users or remove access."""
+    db = get_db()
+    now = datetime.datetime.utcnow()
+    tomorrow = now + datetime.timedelta(days=1)
+    async with db.execute("SELECT user_id, end_date FROM subscription") as cursor:
+        rows = await cursor.fetchall()
+
+    for row in rows:
+        user_id = int(row["user_id"])
+        end_date = datetime.datetime.fromisoformat(row["end_date"])
+
+        if now < end_date <= tomorrow:
+            # Notify user subscription expires in one day
+            try:
+                await bot.send_message(user_id, "Tu suscripción expirará mañana.")
+            except TelegramAPIError:
+                pass
+        elif end_date <= now:
+            await remove_subscription(user_id)
+            try:
+                await bot.send_message(user_id, "Tu suscripción ha expirado.")
+            except TelegramAPIError:
+                pass
+
+
+async def monitor_subscriptions() -> None:
+    """Background task that runs once every 24 hours."""
+    while True:
+        await _check_subscriptions()
+        await asyncio.sleep(24 * 60 * 60)
+
+


### PR DESCRIPTION
## Summary
- run periodic monitor task to check subscription expirations
- send warnings a day before expiration and remove old subs
- launch the monitor when starting the bot

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d96220468832993e2acf97cce1d8a