### PR TITLE
Implement broadcast command

### DIFF
--- a/handlers/admin/__init__.py
+++ b/handlers/admin/__init__.py
@@ -1,3 +1,4 @@
 from .token import router as token_router
+from .broadcast import router as broadcast_router
 
-__all__ = ["token_router"]
+__all__ = ["token_router", "broadcast_router"]

--- a/handlers/admin/broadcast.py
+++ b/handlers/admin/broadcast.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import Message
+
+from bot import bot
+from database import get_db
+from services.subscription_service import list_active_subscriptions
+
+router = Router()
+
+
+@router.message(Command("broadcast"))
+async def cmd_broadcast(message: Message, command: Command.CommandObject) -> None:
+    db = get_db()
+    tg_user = message.from_user
+    if tg_user is None:
+        return
+
+    # Only admins can broadcast
+    async with db.execute("SELECT is_admin FROM user WHERE id=?", (tg_user.id,)) as cur:
+        row = await cur.fetchone()
+    if not (row and row["is_admin"] == 1):
+        await message.answer("No tienes permiso para usar este comando")
+        return
+
+    text = command.args.strip() if command.args else None
+    if not text:
+        await message.answer("Uso: /broadcast <texto>")
+        return
+
+    subs = await list_active_subscriptions()
+    sent = 0
+    for sub in subs:
+        try:
+            await bot.send_message(sub.user_id, text)
+            sent += 1
+        except Exception:
+            # Ignore delivery errors (user blocked bot, etc.)
+            pass
+
+    await message.answer(f"Mensaje enviado a {sent} usuarios")

--- a/main.py
+++ b/main.py
@@ -3,13 +3,14 @@ import asyncio
 from bot import bot, dp
 from database import init_db
 from handlers.user import start_router
-from handlers.admin import token_router
+from handlers.admin import token_router, broadcast_router
 
 
 async def main() -> None:
     await init_db()
     dp.include_router(start_router)
     dp.include_router(token_router)
+    dp.include_router(broadcast_router)
     await dp.start_polling(bot)
 
 


### PR DESCRIPTION
## Summary
- add admin broadcast command for sending private messages to all active subscriptions
- export broadcast router and register it in main app

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d95b4cfcc8329be54d0eb3a04cb57