### PR TITLE
Fix aiogram parse_mode deprecation

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,11 @@
 from aiogram import Bot, Dispatcher
+from aiogram.client.default import DefaultBotProperties
 from aiogram.fsm.storage.memory import MemoryStorage
 
 from config import settings
 
-bot = Bot(token=settings.BOT_TOKEN, parse_mode="HTML")
+bot = Bot(
+    token=settings.BOT_TOKEN,
+    default=DefaultBotProperties(parse_mode="HTML"),
+)
 dp = Dispatcher(storage=MemoryStorage())


### PR DESCRIPTION
## Summary
- update aiogram `Bot` initialization to use `DefaultBotProperties`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d9af0b4788329832d0de898608fc0