### PR TITLE
Fix Telegram entity parsing

### DIFF
--- a/handlers/admin/broadcast.py
+++ b/handlers/admin/broadcast.py
@@ -27,7 +27,7 @@ async def cmd_broadcast(message: Message, command: Command.CommandObject) -> Non
 
     text = command.args.strip() if command.args else None
     if not text:
-        await message.answer("Uso: /broadcast <texto>")
+        await message.answer("Uso: /broadcast &lt;texto&gt;")
         return
 
     subs = await list_active_subscriptions()

--- a/handlers/admin/token.py
+++ b/handlers/admin/token.py
@@ -30,7 +30,7 @@ async def cmd_gen_token(message: Message, command: Command.CommandObject) -> Non
     except ValueError:
         days = 0
     if days <= 0:
-        await message.answer("Uso: /gen_token <días>")
+        await message.answer("Uso: /gen_token &lt;días&gt;")
         return
 
     token = await generate_token(days)
@@ -52,7 +52,7 @@ async def cmd_join(message: Message, command: Command.CommandObject) -> None:
 
     token = command.args.strip() if command.args else None
     if not token:
-        await message.answer("Uso: /join <token>")
+        await message.answer("Uso: /join &lt;token&gt;")
         return
 
     duration = await validate_token(token)

--- a/handlers/admin/users.py
+++ b/handlers/admin/users.py
@@ -29,19 +29,19 @@ async def cmd_add_sub(message: Message, command: Command.CommandObject) -> None:
         return
 
     if not command.args:
-        await message.answer("Uso: /add_sub <@user> <d\u00edas>")
+        await message.answer("Uso: /add_sub &lt;@user&gt; &lt;d\u00edas&gt;")
         return
 
     parts = command.args.split()
     if len(parts) != 2:
-        await message.answer("Uso: /add_sub <@user> <d\u00edas>")
+        await message.answer("Uso: /add_sub &lt;@user&gt; &lt;d\u00edas&gt;")
         return
 
     username = parts[0].lstrip("@").strip()
     try:
         days = int(parts[1])
     except ValueError:
-        await message.answer("Uso: /add_sub <@user> <d\u00edas>")
+        await message.answer("Uso: /add_sub &lt;@user&gt; &lt;d\u00das&gt;")
         return
 
     async with db.execute("SELECT id FROM user WHERE username=?", (username,)) as cur:
@@ -65,7 +65,7 @@ async def cmd_remove_sub(message: Message, command: Command.CommandObject) -> No
         return
 
     if not command.args:
-        await message.answer("Uso: /remove_sub <@user>")
+        await message.answer("Uso: /remove_sub &lt;@user&gt;")
         return
 
     username = command.args.strip().lstrip("@").strip()

--- a/handlers/user/start.py
+++ b/handlers/user/start.py
@@ -57,5 +57,5 @@ async def cmd_start(message: Message, command: Command.CommandObject) -> None:
         await message.answer("Menú de suscriptor")
     else:
         await message.answer(
-            "No estás registrado. Solicita un token y envía /start <token> para suscribirte."
+            "No estás registrado. Solicita un token y envía /start &lt;token&gt; para suscribirte."
         )


### PR DESCRIPTION
## Summary
- escape angle brackets in help messages

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684d9eb24dd0832982c7fdba2111d6dc