### PR TITLE
Fix missing BOT_TOKEN detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Guardian del Diván
+
+Este bot de Telegram gestiona suscripciones y requiere un token para funcionar.
+
+## Instalación
+
+1. Instala las dependencias:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Copia `.env.example` a `.env` y añade tu `BOT_TOKEN` de Telegram:
+   ```bash
+   cp .env.example .env
+   echo "BOT_TOKEN=TU_TOKEN_AQUI" >> .env
+   ```
+
+## Ejecución
+
+Inicia el bot ejecutando `python main.py`. Si `BOT_TOKEN` no está definido se
+mostrará un error indicando cómo configurarlo.
+

--- a/config.py
+++ b/config.py
@@ -8,4 +8,12 @@ load_dotenv()
 class Settings:
     BOT_TOKEN: str = os.getenv("BOT_TOKEN", "")
 
+    def __post_init__(self) -> None:
+        if not self.BOT_TOKEN:
+            raise RuntimeError(
+                "BOT_TOKEN environment variable is not set. "
+                "Create a .env file based on .env.example or set the variable "
+                "before running the bot."
+            )
+
 settings = Settings()


### PR DESCRIPTION
## Summary
- detect missing BOT_TOKEN in config and give clear error
- add README with setup instructions

## Testing
- `python main.py` *(fails: BOT_TOKEN environment variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_684db6497b688329808245aee5a8d0d6