### PR TITLE
Add inline menus for admin and user UX

### DIFF
--- a/handlers/admin/__init__.py
+++ b/handlers/admin/__init__.py
@@ -2,5 +2,12 @@ from .token import router as token_router
 from .users import router as users_router
 from .broadcast import router as broadcast_router
 from .config import router as config_router
+from .menu import ADMIN_MENU_KB
 
-__all__ = ["token_router", "users_router", "broadcast_router", "config_router"]
+__all__ = [
+    "token_router",
+    "users_router",
+    "broadcast_router",
+    "config_router",
+    "ADMIN_MENU_KB",
+]

--- a/handlers/admin/menu.py
+++ b/handlers/admin/menu.py
@@ -1,0 +1,13 @@
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+__all__ = ["ADMIN_MENU_KB"]
+
+ADMIN_MENU_KB = InlineKeyboardMarkup(
+    inline_keyboard=[
+        [InlineKeyboardButton(text="Generar Token", callback_data="admin_gen_token")],
+        [InlineKeyboardButton(text="Usuarios", callback_data="admin_users")],
+        [InlineKeyboardButton(text="Configurar mensajes", callback_data="admin_config_messages")],
+        [InlineKeyboardButton(text="Estadísticas", callback_data="admin_stats")],
+    ]
+)
+

--- a/handlers/user/__init__.py
+++ b/handlers/user/__init__.py
@@ -1,3 +1,4 @@
 from .start import router as start_router
+from .menu import USER_MENU_KB
 
-__all__ = ["start_router"]
+__all__ = ["start_router", "USER_MENU_KB"]

--- a/handlers/user/menu.py
+++ b/handlers/user/menu.py
@@ -1,0 +1,12 @@
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+__all__ = ["USER_MENU_KB"]
+
+USER_MENU_KB = InlineKeyboardMarkup(
+    inline_keyboard=[
+        [InlineKeyboardButton(text="Mi perfil", callback_data="profile")],
+        [InlineKeyboardButton(text="Ayuda", callback_data="help")],
+        [InlineKeyboardButton(text="Estado de suscripción", callback_data="subscription_status")],
+    ]
+)
+

--- a/handlers/user/start.py
+++ b/handlers/user/start.py
@@ -6,6 +6,9 @@ from aiogram import Router
 from aiogram.filters import Command
 from aiogram.types import Message
 
+from handlers.user.menu import USER_MENU_KB
+from handlers.admin.menu import ADMIN_MENU_KB
+
 from database import get_db
 from services.subscription_service import add_subscription, get_subscription
 from services.token_service import validate_token, mark_token_as_used
@@ -55,8 +58,8 @@ async def cmd_start(message: Message, command: Command.CommandObject) -> None:
     active = sub and sub.end_date > datetime.datetime.utcnow()
 
     if is_admin:
-        await message.answer(messages.ADMIN_MENU)
+        await message.answer(messages.ADMIN_MENU, reply_markup=ADMIN_MENU_KB)
     elif active:
-        await message.answer(messages.SUBSCRIBER_MENU)
+        await message.answer(messages.SUBSCRIBER_MENU, reply_markup=USER_MENU_KB)
     else:
-        await message.answer(messages.NOT_REGISTERED)
+        await message.answer(messages.NOT_REGISTERED, reply_markup=USER_MENU_KB)


### PR DESCRIPTION
## Summary
- provide inline keyboard menus for user and admin interfaces
- export menu keyboards via handler packages
- update `/start` logic to attach menus for better UX

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684db5c2203483298724fad63086f115