### PR TITLE
Implement subscription menu for new users

### DIFF
--- a/bot/messages.py
+++ b/bot/messages.py
@@ -25,6 +25,7 @@ SUB_ACTIVATED_WITH_LINK = (
 )
 ADMIN_MENU = "Menú de administración"
 SUBSCRIBER_MENU = "Menú de suscriptor"
+SUBSCRIPTION_MENU = "Menú de suscripción"
 NOT_REGISTERED = (
     "No estás registrado. Solicita un token y envía /start &lt;token&gt; para suscribirte."
 )

--- a/handlers/user/__init__.py
+++ b/handlers/user/__init__.py
@@ -1,4 +1,4 @@
 from .start import router as start_router
-from .menu import USER_MENU_KB
+from .menu import USER_MENU_KB, SUBSCRIPTION_MENU_KB
 
-__all__ = ["start_router", "USER_MENU_KB"]
+__all__ = ["start_router", "USER_MENU_KB", "SUBSCRIPTION_MENU_KB"]

--- a/handlers/user/menu.py
+++ b/handlers/user/menu.py
@@ -1,12 +1,19 @@
 from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
-__all__ = ["USER_MENU_KB"]
+__all__ = ["USER_MENU_KB", "SUBSCRIPTION_MENU_KB"]
 
 USER_MENU_KB = InlineKeyboardMarkup(
     inline_keyboard=[
         [InlineKeyboardButton(text="Mi perfil", callback_data="profile")],
         [InlineKeyboardButton(text="Ayuda", callback_data="help")],
         [InlineKeyboardButton(text="Estado de suscripción", callback_data="subscription_status")],
+    ]
+)
+
+SUBSCRIPTION_MENU_KB = InlineKeyboardMarkup(
+    inline_keyboard=[
+        [InlineKeyboardButton(text="Suscribirme", callback_data="subscribe")],
+        [InlineKeyboardButton(text="Ayuda", callback_data="help")],
     ]
 )
 

--- a/handlers/user/start.py
+++ b/handlers/user/start.py
@@ -6,7 +6,7 @@ from aiogram import Router
 from aiogram.filters import Command
 from aiogram.types import Message
 
-from handlers.user.menu import USER_MENU_KB
+from handlers.user.menu import USER_MENU_KB, SUBSCRIPTION_MENU_KB
 from handlers.admin.menu import ADMIN_MENU_KB
 
 from database import get_db
@@ -62,4 +62,7 @@ async def cmd_start(message: Message, command: Command.CommandObject) -> None:
     elif active:
         await message.answer(messages.SUBSCRIBER_MENU, reply_markup=USER_MENU_KB)
     else:
-        await message.answer(messages.NOT_REGISTERED, reply_markup=USER_MENU_KB)
+        await message.answer(
+            messages.SUBSCRIPTION_MENU,
+            reply_markup=SUBSCRIPTION_MENU_KB,
+        )


### PR DESCRIPTION
## Summary
- allow new users to see a dedicated subscription menu
- export the new keyboard constant
- tweak `/start` logic to show the right menu based on role

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684dbad493b48329980f2c58421d4027