### PR TITLE
Implement admin ids from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 BOT_TOKEN=
+ADMIN_IDS=

--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@ Este bot de Telegram gestiona suscripciones y requiere un token para funcionar.
    pip install -r requirements.txt
    ```
 
-2. Copia `.env.example` a `.env` y añade tu `BOT_TOKEN` de Telegram:
+2. Copia `.env.example` a `.env` y define `BOT_TOKEN` y `ADMIN_IDS`:
    ```bash
    cp .env.example .env
    echo "BOT_TOKEN=TU_TOKEN_AQUI" >> .env
+   echo "ADMIN_IDS=123456789" >> .env
    ```
 
 ## Ejecución
 
-Inicia el bot ejecutando `python main.py`. Si `BOT_TOKEN` no está definido se
-mostrará un error indicando cómo configurarlo.
+Inicia el bot ejecutando `python main.py`. Si `BOT_TOKEN` o `ADMIN_IDS` no están
+definidos se mostrará un error indicando cómo configurarlos.
 

--- a/config.py
+++ b/config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 from dotenv import load_dotenv
 
@@ -7,6 +7,7 @@ load_dotenv()
 @dataclass
 class Settings:
     BOT_TOKEN: str = os.getenv("BOT_TOKEN", "")
+    ADMIN_IDS: list[int] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         if not self.BOT_TOKEN:
@@ -14,6 +15,18 @@ class Settings:
                 "BOT_TOKEN environment variable is not set. "
                 "Create a .env file based on .env.example or set the variable "
                 "before running the bot."
+            )
+
+        admin_ids = os.getenv("ADMIN_IDS", "")
+        if admin_ids:
+            try:
+                self.ADMIN_IDS = [int(x.strip()) for x in admin_ids.split(",") if x.strip()]
+            except ValueError:
+                raise RuntimeError("ADMIN_IDS must be a comma-separated list of integers")
+        if not self.ADMIN_IDS:
+            raise RuntimeError(
+                "ADMIN_IDS environment variable is not set. "
+                "Specify at least one admin Telegram ID before running the bot."
             )
 
 settings = Settings()

--- a/main.py
+++ b/main.py
@@ -2,6 +2,8 @@ import asyncio
 
 from bot import bot, dp
 from database import init_db
+from config import settings
+from services.admin_service import ensure_admins
 from tools.subscription_monitor import monitor_subscriptions
 from handlers.user import start_router
 from handlers.admin import (
@@ -14,6 +16,7 @@ from handlers.admin import (
 
 async def main() -> None:
     await init_db()
+    await ensure_admins(settings.ADMIN_IDS)
     asyncio.create_task(monitor_subscriptions())
     dp.include_router(start_router)
     dp.include_router(token_router)

--- a/services/admin_service.py
+++ b/services/admin_service.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from database import get_db
+
+__all__ = ["ensure_admins"]
+
+
+async def ensure_admins(admin_ids: list[int]) -> None:
+    """Insert or update admin users in the database."""
+    if not admin_ids:
+        return
+    db = get_db()
+    for admin_id in admin_ids:
+        await db.execute(
+            "INSERT OR IGNORE INTO user (id, username, full_name) VALUES (?, ?, ?)",
+            (admin_id, str(admin_id), str(admin_id)),
+        )
+        await db.execute("UPDATE user SET is_admin=1 WHERE id=?", (admin_id,))
+    await db.commit()
+


### PR DESCRIPTION
## Summary
- load new `ADMIN_IDS` env var in settings
- initialize admin users with `ensure_admins`
- document how to set `ADMIN_IDS` and update example env file

## Testing
- `python -m py_compile $(git ls-files '*.py') && pip check`


------
https://chatgpt.com/codex/tasks/task_e_684dbcfe34b8832999905ca7ac7727b9