### PR TITLE
Add inline admin menu and pricing

### DIFF
--- a/bot/messages.py
+++ b/bot/messages.py
@@ -35,3 +35,17 @@ SUB_ADDED = "Suscripción añadida por {days} días para @{username}"
 SUB_REMOVED = "Suscripción eliminada para @{username}"
 REMINDER_UPDATED = "Mensaje de recordatorio actualizado"
 EXPIRATION_UPDATED = "Mensaje de expiración actualizado"
+# Admin menus
+SETTINGS_MENU = "Menú de configuración"
+ADMINISTRATION_MENU = "Herramientas de administración"
+PRICE_UPDATED = "Precio actualizado: {period} - {amount}"
+CURRENT_PRICE = "Precio actual: {period} - {amount}"
+STATS_OVERVIEW = (
+    "Suscriptores activos: {active}\nRenovaciones: {renewals}\nIngresos estimados: {revenue}"
+)
+BROADCAST_INSTRUCTIONS = "Envía /broadcast <texto> para enviar un mensaje a todos los suscriptores"
+ACCESS_LINK = "Enlace de acceso: {link}"
+SUBSCRIBER_INFO = (
+    "Usuario {user_id}\nInicio: {start}\nExpira: {end}\nTotal: {days} días\nRenovaciones: {renewals}"
+)
+USER_REMOVED = "Usuario {user_id} eliminado"

--- a/handlers/admin/__init__.py
+++ b/handlers/admin/__init__.py
@@ -2,12 +2,15 @@ from .token import router as token_router
 from .users import router as users_router
 from .broadcast import router as broadcast_router
 from .config import router as config_router
-from .menu import ADMIN_MENU_KB
+from .menu import ADMIN_MENU_KB, router as menu_router
+from .pricing import router as pricing_router
 
 __all__ = [
     "token_router",
     "users_router",
     "broadcast_router",
     "config_router",
+    "pricing_router",
+    "menu_router",
     "ADMIN_MENU_KB",
 ]

--- a/handlers/admin/menu.py
+++ b/handlers/admin/menu.py
@@ -1,13 +1,112 @@
-from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from __future__ import annotations
 
-__all__ = ["ADMIN_MENU_KB"]
+from aiogram import Router
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup, CallbackQuery
+
+from services.config_service import get_pricing
+from services.subscription_service import list_active_subscriptions, remove_subscription
+from services.token_service import generate_token
+from bot import messages
+from config import settings
+
+router = Router()
+__all__ = ["ADMIN_MENU_KB", "router"]
 
 ADMIN_MENU_KB = InlineKeyboardMarkup(
     inline_keyboard=[
-        [InlineKeyboardButton(text="Generar Token", callback_data="admin_gen_token")],
-        [InlineKeyboardButton(text="Usuarios", callback_data="admin_users")],
-        [InlineKeyboardButton(text="Configurar mensajes", callback_data="admin_config_messages")],
-        [InlineKeyboardButton(text="Estadísticas", callback_data="admin_stats")],
+        [InlineKeyboardButton(text="⚙️ Ajustes", callback_data="admin_settings")],
+        [InlineKeyboardButton(text="🛠️ Administración", callback_data="admin_tools")],
     ]
 )
 
+SETTINGS_MENU_KB = InlineKeyboardMarkup(
+    inline_keyboard=[
+        [InlineKeyboardButton(text="Definir precio", callback_data="settings_set_price")],
+        [InlineKeyboardButton(text="Volver", callback_data="back_admin_menu")],
+    ]
+)
+
+ADMINISTRATION_MENU_KB = InlineKeyboardMarkup(
+    inline_keyboard=[
+        [InlineKeyboardButton(text="Estadísticas", callback_data="admin_stats")],
+        [InlineKeyboardButton(text="Broadcast", callback_data="admin_broadcast")],
+        [InlineKeyboardButton(text="Generar enlace", callback_data="admin_gen_link")],
+        [InlineKeyboardButton(text="Suscriptores", callback_data="admin_list_subs")],
+        [InlineKeyboardButton(text="Volver", callback_data="back_admin_menu")],
+    ]
+)
+
+
+@router.callback_query(lambda c: c.data == "admin_settings")
+async def cb_settings(callback: CallbackQuery) -> None:
+    pricing = await get_pricing()
+    text = messages.SETTINGS_MENU
+    if pricing:
+        text += "\n" + messages.CURRENT_PRICE.format(period=pricing[0], amount=pricing[1])
+    await callback.message.edit_text(text, reply_markup=SETTINGS_MENU_KB)
+    await callback.answer()
+
+
+@router.callback_query(lambda c: c.data == "admin_tools")
+async def cb_tools(callback: CallbackQuery) -> None:
+    await callback.message.edit_text(messages.ADMINISTRATION_MENU, reply_markup=ADMINISTRATION_MENU_KB)
+    await callback.answer()
+
+
+@router.callback_query(lambda c: c.data == "back_admin_menu")
+async def cb_back(callback: CallbackQuery) -> None:
+    await callback.message.edit_text(messages.ADMIN_MENU, reply_markup=ADMIN_MENU_KB)
+    await callback.answer()
+
+
+@router.callback_query(lambda c: c.data == "admin_stats")
+async def cb_stats(callback: CallbackQuery) -> None:
+    subs = await list_active_subscriptions()
+    active = len(subs)
+    pricing = await get_pricing()
+    amount = float(pricing[1]) if pricing else 0
+    revenue = active * amount
+    text = messages.STATS_OVERVIEW.format(active=active, renewals=0, revenue=revenue)
+    await callback.message.answer(text)
+    await callback.answer()
+
+
+@router.callback_query(lambda c: c.data == "admin_broadcast")
+async def cb_broadcast(callback: CallbackQuery) -> None:
+    await callback.message.answer(messages.BROADCAST_INSTRUCTIONS)
+    await callback.answer()
+
+
+@router.callback_query(lambda c: c.data == "admin_gen_link")
+async def cb_gen_link(callback: CallbackQuery) -> None:
+    token = await generate_token(7)
+    link = f"https://t.me/{settings.BOT_TOKEN.split(':')[0]}?start={token}"
+    await callback.message.answer(messages.ACCESS_LINK.format(link=link))
+    await callback.answer()
+
+
+@router.callback_query(lambda c: c.data == "admin_list_subs")
+async def cb_list_subs(callback: CallbackQuery) -> None:
+    subs = await list_active_subscriptions()
+    for sub in subs:
+        days = (sub.end_date - sub.start_date).days
+        text = messages.SUBSCRIBER_INFO.format(
+            user_id=sub.user_id,
+            start=sub.start_date.date(),
+            end=sub.end_date.date(),
+            days=days,
+            renewals=0,
+        )
+        kb = InlineKeyboardMarkup(
+            inline_keyboard=[[InlineKeyboardButton(text="Eliminar", callback_data=f"remove_user:{sub.user_id}")]]
+        )
+        await callback.message.answer(text, reply_markup=kb)
+    await callback.answer()
+
+
+@router.callback_query(lambda c: c.data.startswith("remove_user:"))
+async def cb_remove(callback: CallbackQuery) -> None:
+    user_id = int(callback.data.split(":", 1)[1])
+    await remove_subscription(user_id)
+    await callback.message.answer(messages.USER_REMOVED.format(user_id=user_id))
+    await callback.answer()

--- a/handlers/admin/pricing.py
+++ b/handlers/admin/pricing.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import Message
+
+from services.config_service import set_pricing
+from database import get_db
+from bot import messages
+
+router = Router()
+
+
+async def _ensure_admin(tg_id: int) -> bool:
+    db = get_db()
+    async with db.execute("SELECT is_admin FROM user WHERE id=?", (tg_id,)) as cur:
+        row = await cur.fetchone()
+    return bool(row and row["is_admin"] == 1)
+
+
+@router.message(Command("set_price"))
+async def cmd_set_price(message: Message, command: Command.CommandObject) -> None:
+    tg_user = message.from_user
+    if tg_user is None:
+        return
+    if not await _ensure_admin(tg_user.id):
+        await message.answer(messages.ADMIN_ONLY)
+        return
+    if not command.args:
+        await message.answer("Uso: /set_price <periodo> <cantidad>")
+        return
+    parts = command.args.split()
+    if len(parts) != 2:
+        await message.answer("Uso: /set_price <periodo> <cantidad>")
+        return
+    period = parts[0]
+    amount = parts[1]
+    await set_pricing(period, amount)
+    await message.answer(messages.PRICE_UPDATED.format(period=period, amount=amount))

--- a/main.py
+++ b/main.py
@@ -11,6 +11,8 @@ from handlers.admin import (
     users_router,
     broadcast_router,
     config_router,
+    pricing_router,
+    menu_router,
 )
 
 
@@ -23,6 +25,8 @@ async def main() -> None:
     dp.include_router(users_router)
     dp.include_router(broadcast_router)
     dp.include_router(config_router)
+    dp.include_router(pricing_router)
+    dp.include_router(menu_router)
     await dp.start_polling(bot)
 
 

--- a/services/config_service.py
+++ b/services/config_service.py
@@ -5,6 +5,8 @@ from database import get_db
 __all__ = [
     "get_config",
     "set_config",
+    "get_pricing",
+    "set_pricing",
 ]
 
 
@@ -27,3 +29,15 @@ async def set_config(key: str, value: str) -> None:
         (key, value),
     )
     await db.commit()
+
+async def get_pricing() -> Optional[tuple[str, str]]:
+    period = await get_config("price_period")
+    amount = await get_config("price_amount")
+    if period is None or amount is None:
+        return None
+    return period, amount
+
+
+async def set_pricing(period: str, amount: str) -> None:
+    await set_config("price_period", period)
+    await set_config("price_amount", amount)


### PR DESCRIPTION
## Summary
- extend message templates with pricing and admin text
- provide config helpers for pricing
- implement new inline admin menus with callbacks
- add `/set_price` command for admins
- wire new routers into main

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684dc1f8f71c8329a7f4a558d6f919d8