### PR TITLE
Fix HTML tag parsing in usage messages

### DIFF
--- a/bot/messages.py
+++ b/bot/messages.py
@@ -16,6 +16,7 @@ ADD_SUB_USAGE = "Uso: /add_sub &lt;@user&gt; &lt;días&gt;"
 REMOVE_SUB_USAGE = "Uso: /remove_sub &lt;@user&gt;"
 SET_REMINDER_USAGE = "Uso: /set_reminder &lt;texto&gt;"
 SET_EXPIRATION_USAGE = "Uso: /set_expiration &lt;texto&gt;"
+SET_PRICE_USAGE = "Uso: /set_price &lt;periodo&gt; &lt;cantidad&gt;"
 
 # Success / info messages
 TOKEN_GENERATED = "Token generado: <code>{token}</code>"
@@ -54,7 +55,9 @@ BOLD_STATS = (
     "\ud83d\udd54 Local time: {time} ({tz})\n"
     "\ud83d\udcb1 Currency: {currency}"
 )
-BROADCAST_INSTRUCTIONS = "Envía /broadcast <texto> para enviar un mensaje a todos los suscriptores"
+BROADCAST_INSTRUCTIONS = (
+    "Envía /broadcast &lt;texto&gt; para enviar un mensaje a todos los suscriptores"
+)
 ACCESS_LINK = "Enlace de acceso: {link}"
 SUBSCRIBER_INFO = (
     "Usuario {user_id}\nInicio: {start}\nExpira: {end}\nTotal: {days} días\nRenovaciones: {renewals}"

--- a/handlers/admin/pricing.py
+++ b/handlers/admin/pricing.py
@@ -27,11 +27,11 @@ async def cmd_set_price(message: Message, command: Command.CommandObject) -> Non
         await message.answer(messages.ADMIN_ONLY)
         return
     if not command.args:
-        await message.answer("Uso: /set_price <periodo> <cantidad>")
+        await message.answer(messages.SET_PRICE_USAGE)
         return
     parts = command.args.split()
     if len(parts) != 2:
-        await message.answer("Uso: /set_price <periodo> <cantidad>")
+        await message.answer(messages.SET_PRICE_USAGE)
         return
     period = parts[0]
     amount = parts[1]


### PR DESCRIPTION
## Summary
- prevent HTML entity errors in broadcast instruction
- add usage constant for `/set_price`
- reuse constant in pricing handler

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684dd264e36c8329b2c9d8b2019a577a